### PR TITLE
Handle zeros

### DIFF
--- a/romin/deriv_check.py
+++ b/romin/deriv_check.py
@@ -204,7 +204,8 @@ def deriv_check(f, g, xs, eps_x=1e-4, order=8, nrep=None, rel_ftol=1e-3, discard
     # some info on screen
     if verbose:
         print 'Number of comparisons: %i' % len(deltas)
-        ratios = abs((deltas - deltas_approx)/deltas)
+        with np.errstate(divide='ignore'):
+            ratios = abs(deltas - deltas_approx)/abs(deltas)
         print 'Best:  %10.3e' % np.nanmin(ratios)
         print 'Worst: %10.3e' % np.nanmax(ratios)
         if np.any(np.isnan(ratios)):

--- a/romin/deriv_check.py
+++ b/romin/deriv_check.py
@@ -204,9 +204,11 @@ def deriv_check(f, g, xs, eps_x=1e-4, order=8, nrep=None, rel_ftol=1e-3, discard
     # some info on screen
     if verbose:
         print 'Number of comparisons: %i' % len(deltas)
-        ratios = abs(deltas - deltas_approx)/abs(deltas)
-        print 'Best:  %10.3e' % ratios.min()
-        print 'Worst: %10.3e' % ratios.max()
+        ratios = abs((deltas - deltas_approx)/deltas)
+        print 'Best:  %10.3e' % np.nanmin(ratios)
+        print 'Worst: %10.3e' % np.nanmax(ratios)
+        if np.any(np.isnan(ratios)):
+            print 'Warning: encountered NaN.'
         #abs(deltas - deltas_approx) < rel_ftol*abs(deltas)
     # final test
-    assert np.all(abs(deltas - deltas_approx) < rel_ftol*abs(deltas))
+    assert np.all(abs(deltas - deltas_approx) <= rel_ftol*abs(deltas))

--- a/romin/test/test_derivcheck.py
+++ b/romin/test/test_derivcheck.py
@@ -73,3 +73,17 @@ def check_deriv_check_extra1(nx):
 def test_deriv_check_extra1():
     yield check_deriv_check_extra1, 1
     yield check_deriv_check_extra1, 10
+
+
+def check_deriv_check_nd_zeros(nx, x_shape):
+    f = lambda x: np.ones(x.shape)
+    g = lambda x: np.zeros(x.shape)
+    xs = [np.random.normal(0, 1, x_shape) for ix in xrange(nx)]
+    deriv_check(f, g, xs)
+
+
+def test_deriv_check_nd_zeros():
+    yield check_deriv_check_nd, 1, (10, )
+    yield check_deriv_check_nd, 1, (3, 4)
+    yield check_deriv_check_nd, 10, (10, )
+    yield check_deriv_check_nd, 10, (3, 4)


### PR DESCRIPTION
Added the handle to ignore div/0 warnings, reverted the useless change to `ratios = ...`.
